### PR TITLE
add optuna contents

### DIFF
--- a/config/config_optuna.yaml
+++ b/config/config_optuna.yaml
@@ -1,0 +1,50 @@
+comment: Commentaire sur l'entraînement
+
+wandb:
+  name_project: "optuna-wandb-example"
+  entity: "optuna-wandb-example"
+  name_run:
+
+data:
+  csv_file: ../tensorflow-great-barrier-reef/train.csv
+  root_path: ../tensorflow-great-barrier-reef/train_images
+
+augmentation:
+  size:
+    w: 1280
+    h: 720
+
+configs:
+  epoch: 2
+  batch_size: 2
+  seed: 1
+  checkpoint:
+    monitor: "validation/F2_score"
+    mode: "max"
+  early_stopping:
+    monitor: "train/loss_sum"
+    mode: "min"
+    patience: 80
+
+model:
+  name: model.RetinaNet.RetinaNet
+  params:
+    pretrained: True
+    pretrained_backbone: True
+
+optimizer:
+  name: torch.optim.SGD
+  params:
+    lr: 0.005
+    momentum : 0.9
+
+scheduler:
+  name: torch.optim.lr_scheduler.CosineAnnealingLR
+  params:
+    T_max: 150
+    eta_min: 0.00001
+
+optuna:
+  run: True
+  trials: 2
+

--- a/main_optuna.py
+++ b/main_optuna.py
@@ -1,7 +1,7 @@
 '''
     Author: Clément APAVOU
 '''
-from agents.trainer import Trainer
+from agents.trainer_optuna import Trainer
 from utils.logger import init_logger
 import argparse
 


### PR DESCRIPTION
add optuna contents

### 1. requirements.txt
- optuna install info (pip install optuna==2.10.0)

### 2. main_optuna.py
- almost same as `main.py`
- only difference in line 4 : `from agents.trainer import Trainer` to `from agents.trainer_optuna import Trainer`

### 3. agents/trainer_optuna.py
- add optuna settings, such as `wandb callback`, `objective function`, etc..

### 4. config/config_optuna.yaml
- new configure for executing `main_optuna.py`